### PR TITLE
Update chef server package url to latest version 12.0.4

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 ## Todo: generate it through api when Omnitruck API issue(i.e It doesn't give latest chef-server package) resolved
 default['chef-server-image']['package_name'] = "chef-server"
 default['chef-server-image']['package_version'] = ""
-default['chef-server-image']['package_url'] = "https://web-dl.packagecloud.io/chef/stable/packages/ubuntu/precise/chef-server-core_12.0.0-1_amd64.deb"
+default['chef-server-image']['package_url'] = "https://web-dl.packagecloud.io/chef/stable/packages/ubuntu/trusty/chef-server-core_12.0.4-1_amd64.deb"
 default['chef']['install_path'] = "/opt/opscode"
 default['chef-server']['configuration'] = {}
 default['chef']['addons']['ubuntu_supported_codenames'] =  %w{lucid natty precise}

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -70,7 +70,7 @@ when 'ubuntu'
         ###
         #############################################################################################"
      fi
-     ' >> ~/.bashrc
+     ' >> /etc/bash.bashrc
     EOH
   end
   # Delete chef config files.


### PR DESCRIPTION
Changes to update default chef-server package url for version 12.0.4.

