### PR TITLE
chef-server-setup should prompt when run without flags

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -59,10 +59,7 @@ when 'ubuntu'
        echo "
         #############################################################################################
         ## Run following command to install and configure Chef Server
-        ## $ sudo chef-server-setup -u <username> -p <password> -o <organizations-short-name>
-        ## Example:
-        ##   sudo chef-server-setup -u sysadmin -p \$MYPASSWORD -o engineering
-        ## Use -? option for additional customization options 
+        ## $ sudo chef-server-setup
         #############################################################################################"
      else
        echo "

--- a/templates/default/chef-server-image.erb
+++ b/templates/default/chef-server-image.erb
@@ -63,8 +63,10 @@ shift $((OPTIND-1))
 
 # Prompt if user missed any option.
 if [ -z "${user}" ];then
-  echo "Enter user name for chef-server:"
-  read user
+  user="admin" 
+  echo "Enter user name for chef-server (default is admin):"
+  read username
+  [ -n "$username" ] && user=$username
 fi
 
 if [ -z "${userFirstName}" ];then
@@ -80,13 +82,16 @@ if [ -z "${email}" ];then
 fi
 
 if [ -z "${password}" ];then
-  echo "Enter secure password for user:"
-  read password
+  while read -s -p 'Enter new password: ' password && [[ -z "$password" ]] ; do
+    echo -e "\n Password should not be blank!"
+  done  
 fi
 
 if [ -z "${orgShortName}" ];then
-  echo "Enter Organization's short name:"
-  read orgShortName
+  orgShortName="azure"
+  echo "Enter Organization's short name (default is azure):"
+  read shortname
+  [ -n "$shortname" ] && orgShortName=$shortname
 fi
 
 if [ -z "${orgFullName}" ];then
@@ -97,17 +102,27 @@ if [ -z "${user}" ] || [ -z "${userFirstName}" ] || [ -z "${userLastName}" ] || 
   usage
 fi
 
-## Install Chef Server
-
-echo "This may take 30 minutes or more"
-sleep 15
-temp_dir="/opt/chef/chef-server-package"
-
 <% if node['azure'] %>
   api_fqdn="$(sudo cat /etc/resolv.conf | grep search | awk '{print $2}' | cut -d . -f 1).cloudapp.net"
 <% else %>
   api_fqdn="$(sudo cat /etc/resolv.conf | grep search | awk '{print $2}')"
 <% end %>
+
+echo "Chef server details"
+echo  "Username:  $user"
+echo  "FQDN    :  $api_fqdn"
+
+read -p "Do you want to proceed for installation (y/n)?" choice
+if [ "$choice" == "n" ]; then
+  echo "You can run chef-server-setup -? to see detailed options, or just run chef-server-setup to try again."
+  exit 0
+fi
+
+## Install Chef Server
+
+echo "This may take 30 minutes or more"
+sleep 15
+temp_dir="/opt/chef/chef-server-package"
 
 <% if node['chef-server-image']['package_url'] %>
   sudo mkdir $temp_dir
@@ -155,6 +170,7 @@ api_fqdn $api_fqdn
 <%= component.gsub('-', '_') %> "<%= tunables %>"
 <% end -%>
 <% end -%>
+
 EOP
 
 sudo chef-server-ctl reconfigure


### PR DESCRIPTION
> Updated default log on message banner to run chef-server-setup removed command with options.
> Username set default to 'admin' if not entered by user.
> Hided text for password field and updated coded to prompt user if password is not provided.
> Organisation default name set to 'azure' if user not provides it.
> Listing username and FQDN and added confirmation prompt to proceed the installation or not.