### PR TITLE
Added prompt for accepting end user license agreement and also provided cmd line option -L to accept license

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -50,6 +50,26 @@ when 'ubuntu'
     to "#{chef_path}/chef-server-setup"
   end
 
+  
+  unless File.directory?('/opt/opscode')
+    directory "/opt/opscode" do
+      owner 'root'
+      group 'root'
+      mode '0755'
+      action :create
+    end 
+  end
+
+  # creating LICENSE file on server on /opt/opscode location
+  license_file = File.expand_path('../../LICENSE', __FILE__)
+  file '/opt/opscode/LICENSE' do
+    content File.read("#{license_file}")
+    owner 'root'
+    group 'root'
+    mode '444'
+    action :create
+  end
+
   bash "update .bashrc to show chef-server configuration help" do
     cwd "#{ENV['HOME']}"
     code <<-EOH

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -49,7 +49,6 @@ when 'ubuntu'
   link "/usr/bin/chef-server-setup" do
     to "#{chef_path}/chef-server-setup"
   end
-
   
   unless File.directory?('/opt/opscode')
     directory "/opt/opscode" do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -59,16 +59,6 @@ when 'ubuntu'
     end 
   end
 
-  # creating LICENSE file on server on /opt/opscode location
-  license_file = File.expand_path('../../LICENSE', __FILE__)
-  file '/opt/opscode/LICENSE' do
-    content File.read("#{license_file}")
-    owner 'root'
-    group 'root'
-    mode '444'
-    action :create
-  end
-
   bash "update .bashrc to show chef-server configuration help" do
     cwd "#{ENV['HOME']}"
     code <<-EOH

--- a/templates/default/chef-server-image.erb
+++ b/templates/default/chef-server-image.erb
@@ -66,13 +66,14 @@ done
 shift $((OPTIND-1))
 
 if [ -z "${acceptLicense}" ];then
-  read -p "Do you agree to the End User License Agreement located at /opt/opscode/LICENSE (y/n)?" choice
-  if [ "$choice" != "y" ]; then
+  read -p "By continuing you are bound to the terms here: https://www.chef.io/online-master-agreement/ Type 'yes' if you agree (yes/no)?" choice
+  if [ "$choice" != 'yes' ]; then
     echo "License agreement needs to be accpeted for installation."
     exit 0
   fi
 fi
 
+## creating End user license agreement acceptance log file
 cat > /opt/opscode/chef_server_license.log <<EOP
 Chef Server End User License accepted on : <%= Time.now %>
 EOP

--- a/templates/default/chef-server-image.erb
+++ b/templates/default/chef-server-image.erb
@@ -18,6 +18,7 @@ echo "-f                user-first-name";
 echo "-l                user-last-name";
 echo "-e                email-id";
 echo "-o                organization-short-name";
+echo "-L                accept-license";
 echo "-F                organization-full-name" 1>&2; exit 1; }
 
 # Check last run command status.
@@ -30,7 +31,7 @@ checkStatus() {
 }
 
 ## Take chef server configuration from user
-while getopts ":u:f:l:e:p:o:F:" opt; do
+while getopts ":u:f:l:e:p:o:F:L" opt; do
   case "${opt}" in
     u)
       user=${OPTARG}
@@ -53,6 +54,9 @@ while getopts ":u:f:l:e:p:o:F:" opt; do
     F)
       orgFullName=${OPTARG}
       ;;
+    L)
+      acceptLicense=true
+      ;;
     *)
       usage
       ;;
@@ -60,6 +64,18 @@ while getopts ":u:f:l:e:p:o:F:" opt; do
 done
 
 shift $((OPTIND-1))
+
+if [ -z "${acceptLicense}" ];then
+  read -p "Do you agree to the End User License Agreement located at /opt/opscode/LICENSE (y/n)?" choice
+  if [ "$choice" != "y" ]; then
+    echo "License agreement needs to be accpeted for installation."
+    exit 0
+  fi
+fi
+
+cat > /opt/opscode/chef_server_license.log <<EOP
+Chef Server End User License accepted on : <%= Time.now %>
+EOP
 
 # Prompt if user missed any option.
 if [ -z "${user}" ];then


### PR DESCRIPTION
Creating LICENSE file in /opt/opscode and prompting user to read that file and accept the End User License before proceeding for installation.
Provided command line option which user can provide while run chef server setup command, this will skip prompt for accepting license and move on to installation process. 
On acceptance of agreement logged the details i.e. date of acceptance in chef_server_license.log